### PR TITLE
chore: bump workflows version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   lint_test:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@v0.11.1
+    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@v0.11.2
     with:
       go-version: '1.23'
       go-lint-version: 'v1.60.2'
@@ -19,7 +19,7 @@ jobs:
       gosec-args: "-exclude-generated -exclude-dir=itest -exclude-dir=testutil -exclude-dir=covenant-signer ./..."
 
   docker_pipeline:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.11.1
+    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.11.2
     secrets: inherit
     with:
       publish: false
@@ -47,7 +47,7 @@ jobs:
         run: gosec ./...
 
   docker_pipeline_covenant_signer:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.11.1
+    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.11.2
     secrets: inherit
     with:
       publish: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   lint_test:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@hiep/fix-duplicate-artifact
+    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@v0.11.2
     with:
       go-version: '1.23'
       go-lint-version: 'v1.60.2'
@@ -23,7 +23,7 @@ jobs:
 
   docker_pipeline:
     needs: ["lint_test"]
-    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@hiep/fix-duplicate-artifact
+    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.11.2
     secrets: inherit
     with:
       publish: true
@@ -57,7 +57,7 @@ jobs:
   
   docker_pipeline_covenant_signer:
     needs: ["go_sec_covenant_signer"]
-    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@hiep/fix-duplicate-artifact
+    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.11.2
     secrets: inherit
     with:
       publish: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 'main'
-      - 'hiep/fix-docker-pipeline'
     tags:
       - '*'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,12 +4,13 @@ on:
   push:
     branches:
       - 'main'
+      - 'hiep/fix-docker-pipeline'
     tags:
       - '*'
 
 jobs:
   lint_test:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@v0.11.1
+    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@hiep/fix-duplicate-artifact
     with:
       go-version: '1.23'
       go-lint-version: 'v1.60.2'
@@ -22,7 +23,7 @@ jobs:
 
   docker_pipeline:
     needs: ["lint_test"]
-    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.11.1
+    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@hiep/fix-duplicate-artifact
     secrets: inherit
     with:
       publish: true
@@ -56,7 +57,7 @@ jobs:
   
   docker_pipeline_covenant_signer:
     needs: ["go_sec_covenant_signer"]
-    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.11.1
+    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@hiep/fix-duplicate-artifact
     secrets: inherit
     with:
       publish: true


### PR DESCRIPTION
This PR bumps the workflows version to fix the docker_pipeline [bug](https://github.com/babylonlabs-io/covenant-emulator/actions/runs/12137233973) that uploads container image digests to the same artifact.
Related workflow change: https://github.com/babylonlabs-io/.github/pull/31
Tested with this workflow run: https://github.com/babylonlabs-io/covenant-emulator/actions/runs/12171840414