### PR TITLE
chore: add release v0.10.0 to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
 
+## v0.10.0
+
 ### Improvements
 
 * [#43](https://github.com/babylonlabs-io/covenant-emulator/pull/43) Test importing


### PR DESCRIPTION
messup the release process and forgot to add the changelog before creating the branch release/v0.10.0