### PR TITLE
docs: fix invalid link README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ verified the validity of the transactions and sent corresponding signatures.
 
 Upon a pending staking request being found, the covenant emulation daemon 
 (`covd`), validates it against the spending rules defined in
-[Staking Script specification](https://github.com/babylonlabs-io/babylon/blob/dev/docs/staking-script.md),
+[Staking Script specification](https://github.com/babylonlabs-io/babylon/blob/main/docs/staking-script.md),
 and sends three types of signatures to the Babylon chain:
 
 1. **Slashing signature**. This signature is an [adaptor signature](https://bitcoinops.org/en/topics/adaptor-signatures/),


### PR DESCRIPTION
# Rationale for this change

There is invalid link in the document.

# Changes

Fix invalid link in the document. The commit explains which link is invalid and how it is fixed.