### PR TITLE
chore: add pagination to queryDelegationsWithStatus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * [#83](https://github.com/babylonlabs-io/covenant-emulator/pull/83) covenant-signer: remove go.mod
 * [#95](https://github.com/babylonlabs-io/covenant-emulator/pull/95) removed local signer option
 as the covenant emulator should only connect to a remote signer
+* [#96](https://github.com/babylonlabs-io/covenant-emulator/pull/96) add pagination to `queryDelegationsWithStatus`
 
 ## v0.11.3
 

--- a/clientcontroller/babylon.go
+++ b/clientcontroller/babylon.go
@@ -206,7 +206,7 @@ func (bc *BabylonController) queryDelegationsWithStatus(status btcstakingtypes.B
 		Limit: pgLimit,
 	}
 
-	dels := make([]*types.Delegation, delsLimit)
+	dels := make([]*types.Delegation, 0, delsLimit)
 	indexDels := uint64(0)
 
 	for indexDels <= delsLimit {

--- a/clientcontroller/babylon.go
+++ b/clientcontroller/babylon.go
@@ -230,7 +230,7 @@ func (bc *BabylonController) queryDelegationsWithStatus(status btcstakingtypes.B
 			}
 		}
 
-		if len(res.BtcDelegations) != int(pgLimit) {
+		if uint64(len(res.BtcDelegations)) != pgLimit {
 			return dels, nil
 		}
 		pagination.Key = res.Pagination.NextKey

--- a/clientcontroller/babylon.go
+++ b/clientcontroller/babylon.go
@@ -27,9 +27,10 @@ import (
 	"github.com/babylonlabs-io/covenant-emulator/types"
 )
 
-const maxPaginationLimit = uint64(1000)
-
-var _ ClientController = &BabylonController{}
+var (
+	_                  ClientController = &BabylonController{}
+	MaxPaginationLimit                  = uint64(1000)
+)
 
 type BabylonController struct {
 	bbnClient *bbnclient.Client
@@ -201,7 +202,7 @@ func (bc *BabylonController) QueryVerifiedDelegations(limit uint64) ([]*types.De
 // with the given status (either pending or unbonding)
 // it is only used when the program is running in Covenant mode
 func (bc *BabylonController) queryDelegationsWithStatus(status btcstakingtypes.BTCDelegationStatus, delsLimit uint64) ([]*types.Delegation, error) {
-	pgLimit := min(maxPaginationLimit, delsLimit)
+	pgLimit := min(MaxPaginationLimit, delsLimit)
 	pagination := &sdkquery.PageRequest{
 		Limit: pgLimit,
 	}
@@ -209,7 +210,7 @@ func (bc *BabylonController) queryDelegationsWithStatus(status btcstakingtypes.B
 	dels := make([]*types.Delegation, 0, delsLimit)
 	indexDels := uint64(0)
 
-	for indexDels <= delsLimit {
+	for indexDels < delsLimit {
 		res, err := bc.bbnClient.QueryClient.BTCDelegations(status, pagination)
 		if err != nil {
 			return nil, fmt.Errorf("failed to query BTC delegations: %v", err)
@@ -221,7 +222,7 @@ func (bc *BabylonController) queryDelegationsWithStatus(status btcstakingtypes.B
 				return nil, err
 			}
 
-			dels[indexDels] = del
+			dels = append(dels, del)
 			indexDels++
 
 			if indexDels == delsLimit {

--- a/clientcontroller/interface.go
+++ b/clientcontroller/interface.go
@@ -14,19 +14,22 @@ const (
 	babylonConsumerChainName = "babylon"
 )
 
-type ClientController interface {
-	// SubmitCovenantSigs submits Covenant signatures to the consumer chain, each corresponding to
-	// a finality provider that the delegation is (re-)staked to
-	// it returns tx hash and error
-	SubmitCovenantSigs(covSigMsgs []*types.CovenantSigs) (*types.TxResponse, error)
+type (
+	FilterFn         func(del *types.Delegation) (accept bool, err error)
+	ClientController interface {
+		// SubmitCovenantSigs submits Covenant signatures to the consumer chain, each corresponding to
+		// a finality provider that the delegation is (re-)staked to
+		// it returns tx hash and error
+		SubmitCovenantSigs(covSigMsgs []*types.CovenantSigs) (*types.TxResponse, error)
 
-	// QueryPendingDelegations queries BTC delegations that are in status of pending
-	QueryPendingDelegations(limit uint64) ([]*types.Delegation, error)
+		// QueryPendingDelegations queries BTC delegations that are in status of pending
+		QueryPendingDelegations(limit uint64, filter FilterFn) ([]*types.Delegation, error)
 
-	QueryStakingParamsByVersion(version uint32) (*types.StakingParams, error)
+		QueryStakingParamsByVersion(version uint32) (*types.StakingParams, error)
 
-	Close() error
-}
+		Close() error
+	}
+)
 
 func NewClientController(chainName string, bbnConfig *config.BBNConfig, netParams *chaincfg.Params, logger *zap.Logger) (ClientController, error) {
 	var (

--- a/covenant-signer/keystore/cosmos/keyringcontroller.go
+++ b/covenant-signer/keystore/cosmos/keyringcontroller.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	sdksecp256k1 "github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/go-bip39"
 )
 
@@ -18,6 +19,7 @@ const (
 
 type ChainKeyInfo struct {
 	Name       string
+	Address    sdk.AccAddress
 	Mnemonic   string
 	PublicKey  *btcec.PublicKey
 	PrivateKey *btcec.PrivateKey
@@ -98,6 +100,10 @@ func (kc *ChainKeyringController) CreateChainKey(passphrase, hdPath string) (*Ch
 		return nil, err
 	}
 
+	addr, err := record.GetAddress()
+	if err != nil {
+		return nil, err
+	}
 	privKey := record.GetLocal().PrivKey.GetCachedValue()
 
 	switch v := privKey.(type) {
@@ -105,6 +111,7 @@ func (kc *ChainKeyringController) CreateChainKey(passphrase, hdPath string) (*Ch
 		sk, pk := btcec.PrivKeyFromBytes(v.Key)
 		return &ChainKeyInfo{
 			Name:       kc.keyName,
+			Address:    addr,
 			PublicKey:  pk,
 			PrivateKey: sk,
 			Mnemonic:   mnemonic,

--- a/covenant/covenant_test.go
+++ b/covenant/covenant_test.go
@@ -276,27 +276,26 @@ func TestDeduplicationWithOddKey(t *testing.T) {
 
 	randomKey, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
-	pubKey := randomKey.PubKey()
+	randPubKey := randomKey.PubKey()
 
 	paramVersion := uint32(2)
-	delegations := []*types.Delegation{
-		&types.Delegation{
-			CovenantSigs: []*types.CovenantAdaptorSigInfo{
-				&types.CovenantAdaptorSigInfo{
-					// 3. Delegation is already signed by the public key with odd y coordinate
-					Pk: pubKeyFromSchnorr,
-				},
+	delAlreadySigned := &types.Delegation{
+		CovenantSigs: []*types.CovenantAdaptorSigInfo{
+			&types.CovenantAdaptorSigInfo{
+				// 3. Delegation is already signed by the public key with odd y coordinate
+				Pk: pubKeyFromSchnorr,
 			},
-			ParamsVersion: paramVersion,
 		},
-		&types.Delegation{
-			CovenantSigs: []*types.CovenantAdaptorSigInfo{
-				&types.CovenantAdaptorSigInfo{
-					Pk: pubKey,
-				},
+		ParamsVersion: paramVersion,
+	}
+
+	delNotSigned := &types.Delegation{
+		CovenantSigs: []*types.CovenantAdaptorSigInfo{
+			&types.CovenantAdaptorSigInfo{
+				Pk: randPubKey,
 			},
-			ParamsVersion: paramVersion,
 		},
+		ParamsVersion: paramVersion,
 	}
 
 	paramsGet := NewMockParam(map[uint32]*types.StakingParams{
@@ -306,9 +305,13 @@ func TestDeduplicationWithOddKey(t *testing.T) {
 	})
 
 	// 4. After removing the already signed delegation, the list should have only one element
-	sanitized, err := covenant.SanitizeDelegations(oddKeyPub, paramsGet, delegations)
-	require.Equal(t, 1, len(sanitized))
+	accept, err := covenant.AcceptDelegationToSign(oddKeyPub, paramsGet, delAlreadySigned)
 	require.NoError(t, err)
+	require.False(t, accept)
+
+	accept, err = covenant.AcceptDelegationToSign(oddKeyPub, paramsGet, delNotSigned)
+	require.NoError(t, err)
+	require.True(t, accept)
 }
 
 func TestIsKeyInCommittee(t *testing.T) {
@@ -355,51 +358,50 @@ func TestIsKeyInCommittee(t *testing.T) {
 	actual, err := covenant.IsKeyInCommittee(paramsGet, covenantSerializedPk, delNoCovenant)
 	require.False(t, actual)
 	require.NoError(t, err)
-	emptyDels, err := covenant.SanitizeDelegations(covKeyPair.PublicKey, paramsGet, []*types.Delegation{delNoCovenant, delNoCovenant})
+
+	accept, err := covenant.AcceptDelegationToSign(covKeyPair.PublicKey, paramsGet, delNoCovenant)
 	require.NoError(t, err)
-	require.Len(t, emptyDels, 0)
+	require.False(t, accept)
 
 	// checks the case where the covenant is in the committee
 	actual, err = covenant.IsKeyInCommittee(paramsGet, covenantSerializedPk, delWithCovenant)
 	require.True(t, actual)
 	require.NoError(t, err)
-	dels, err := covenant.SanitizeDelegations(covKeyPair.PublicKey, paramsGet, []*types.Delegation{delWithCovenant, delNoCovenant})
-	require.NoError(t, err)
-	require.Len(t, dels, 1)
-	dels, err = covenant.SanitizeDelegations(covKeyPair.PublicKey, paramsGet, []*types.Delegation{delWithCovenant})
-	require.NoError(t, err)
-	require.Len(t, dels, 1)
 
-	amtSatFirst := btcutil.Amount(100)
-	amtSatSecond := btcutil.Amount(150)
-	amtSatThird := btcutil.Amount(200)
-	lastUnsanitizedDels := []*types.Delegation{
-		&types.Delegation{
-			ParamsVersion: pVersionWithCovenant,
-			TotalSat:      amtSatFirst,
-		},
-		delNoCovenant,
-		&types.Delegation{
-			ParamsVersion: pVersionWithCovenant,
-			TotalSat:      amtSatSecond,
-		},
-		delNoCovenant,
-		&types.Delegation{
-			ParamsVersion: pVersionWithCovenant,
-			TotalSat:      amtSatThird,
-		},
-	}
-
-	sanitizedDels, err := covenant.SanitizeDelegations(covKeyPair.PublicKey, paramsGet, lastUnsanitizedDels)
+	accept, err = covenant.AcceptDelegationToSign(covKeyPair.PublicKey, paramsGet, delWithCovenant)
 	require.NoError(t, err)
-	require.Len(t, sanitizedDels, 3)
-	require.Equal(t, amtSatFirst, sanitizedDels[0].TotalSat)
-	require.Equal(t, amtSatSecond, sanitizedDels[1].TotalSat)
-	require.Equal(t, amtSatThird, sanitizedDels[2].TotalSat)
+	require.True(t, accept)
+
+	// amtSatFirst := btcutil.Amount(100)
+	// amtSatSecond := btcutil.Amount(150)
+	// amtSatThird := btcutil.Amount(200)
+	// lastUnsanitizedDels := []*types.Delegation{
+	// 	&types.Delegation{
+	// 		ParamsVersion: pVersionWithCovenant,
+	// 		TotalSat:      amtSatFirst,
+	// 	},
+	// 	delNoCovenant,
+	// 	&types.Delegation{
+	// 		ParamsVersion: pVersionWithCovenant,
+	// 		TotalSat:      amtSatSecond,
+	// 	},
+	// 	delNoCovenant,
+	// 	&types.Delegation{
+	// 		ParamsVersion: pVersionWithCovenant,
+	// 		TotalSat:      amtSatThird,
+	// 	},
+	// }
+
+	// sanitizedDels, err := covenant.SanitizeDelegations(covKeyPair.PublicKey, paramsGet, lastUnsanitizedDels)
+	// require.NoError(t, err)
+	// require.Len(t, sanitizedDels, 3)
+	// require.Equal(t, amtSatFirst, sanitizedDels[0].TotalSat)
+	// require.Equal(t, amtSatSecond, sanitizedDels[1].TotalSat)
+	// require.Equal(t, amtSatThird, sanitizedDels[2].TotalSat)
 
 	errParamGet := fmt.Errorf("dumbErr")
-	sanitizedDels, err = covenant.SanitizeDelegations(covKeyPair.PublicKey, NewMockParamError(errParamGet), lastUnsanitizedDels)
-	require.Nil(t, sanitizedDels)
+	accept, err = covenant.AcceptDelegationToSign(covKeyPair.PublicKey, NewMockParamError(errParamGet), delWithCovenant)
+	require.False(t, accept)
 
 	errKeyIsInCommittee := fmt.Errorf("unable to get the param version: %d, reason: %s", pVersionWithCovenant, errParamGet.Error())
 	expErr := fmt.Errorf("unable to verify if covenant key is in committee: %s", errKeyIsInCommittee.Error())

--- a/covenant/covenant_test.go
+++ b/covenant/covenant_test.go
@@ -150,7 +150,7 @@ func FuzzAddCovenantSig(f *testing.F) {
 				BtcPk:            delPK,
 				FpBtcPks:         fpPks,
 				StakingTime:      stakingTimeBlocks,
-				StartHeight:      startHeight, // not relevant here
+				StartHeight:      startHeight,
 				EndHeight:        startHeight + stakingTimeBlocks,
 				TotalSat:         btcutil.Amount(stakingValue),
 				UnbondingTime:    unbondingTime,
@@ -371,33 +371,6 @@ func TestIsKeyInCommittee(t *testing.T) {
 	accept, err = covenant.AcceptDelegationToSign(covKeyPair.PublicKey, paramsGet, delWithCovenant)
 	require.NoError(t, err)
 	require.True(t, accept)
-
-	// amtSatFirst := btcutil.Amount(100)
-	// amtSatSecond := btcutil.Amount(150)
-	// amtSatThird := btcutil.Amount(200)
-	// lastUnsanitizedDels := []*types.Delegation{
-	// 	&types.Delegation{
-	// 		ParamsVersion: pVersionWithCovenant,
-	// 		TotalSat:      amtSatFirst,
-	// 	},
-	// 	delNoCovenant,
-	// 	&types.Delegation{
-	// 		ParamsVersion: pVersionWithCovenant,
-	// 		TotalSat:      amtSatSecond,
-	// 	},
-	// 	delNoCovenant,
-	// 	&types.Delegation{
-	// 		ParamsVersion: pVersionWithCovenant,
-	// 		TotalSat:      amtSatThird,
-	// 	},
-	// }
-
-	// sanitizedDels, err := covenant.SanitizeDelegations(covKeyPair.PublicKey, paramsGet, lastUnsanitizedDels)
-	// require.NoError(t, err)
-	// require.Len(t, sanitizedDels, 3)
-	// require.Equal(t, amtSatFirst, sanitizedDels[0].TotalSat)
-	// require.Equal(t, amtSatSecond, sanitizedDels[1].TotalSat)
-	// require.Equal(t, amtSatThird, sanitizedDels[2].TotalSat)
 
 	errParamGet := fmt.Errorf("dumbErr")
 	accept, err = covenant.AcceptDelegationToSign(covKeyPair.PublicKey, NewMockParamError(errParamGet), delWithCovenant)

--- a/itest/babylon_node_handler.go
+++ b/itest/babylon_node_handler.go
@@ -23,14 +23,16 @@ type babylonNode struct {
 	cmd          *exec.Cmd
 	pidFile      string
 	dataDir      string
+	nodeHome     string
 	chainID      string
 	slashingAddr string
 	covenantPk   *types.BIP340PubKey
 }
 
-func newBabylonNode(dataDir string, cmd *exec.Cmd, chainID string, slashingAddr string, covenantPk *types.BIP340PubKey) *babylonNode {
+func newBabylonNode(dataDir, nodeHome string, cmd *exec.Cmd, chainID string, slashingAddr string, covenantPk *types.BIP340PubKey) *babylonNode {
 	return &babylonNode{
 		dataDir:      dataDir,
+		nodeHome:     nodeHome,
 		cmd:          cmd,
 		chainID:      chainID,
 		slashingAddr: slashingAddr,
@@ -122,7 +124,7 @@ func NewBabylonNodeHandler(t *testing.T, covenantPk *types.BIP340PubKey) *Babylo
 		}
 	}()
 
-	nodeDataDir := filepath.Join(testDir, "node0", "babylond")
+	nodeHome := filepath.Join(testDir, "node0", "babylond")
 
 	slashingAddr := "SZtRT4BySL3o4efdGLh3k7Kny8GAnsBrSW"
 	decodedAddr, err := btcutil.DecodeAddress(slashingAddr, &chaincfg.SimNetParams)
@@ -164,14 +166,14 @@ func NewBabylonNodeHandler(t *testing.T, covenantPk *types.BIP340PubKey) *Babylo
 	startCmd := exec.Command(
 		"babylond",
 		"start",
-		fmt.Sprintf("--home=%s", nodeDataDir),
+		fmt.Sprintf("--home=%s", nodeHome),
 		"--log_level=debug",
 	)
 
 	startCmd.Stdout = f
 
 	return &BabylonNodeHandler{
-		babylonNode: newBabylonNode(testDir, startCmd, chainID, slashingAddr, covenantPk),
+		babylonNode: newBabylonNode(testDir, nodeHome, startCmd, chainID, slashingAddr, covenantPk),
 	}
 }
 

--- a/itest/e2e_test.go
+++ b/itest/e2e_test.go
@@ -62,7 +62,7 @@ func TestQueryPendingDelegations(t *testing.T) {
 		_ = tm.InsertBTCDelegation(t, btcPks, stakingTime, stakingAmount, false)
 	}
 
-	dels, err := tm.CovBBNClient.QueryPendingDelegations(uint64(numDels))
+	dels, err := tm.CovBBNClient.QueryPendingDelegations(uint64(numDels), nil)
 	require.NoError(t, err)
 	require.Len(t, dels, numDels)
 }

--- a/itest/e2e_test.go
+++ b/itest/e2e_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/babylonlabs-io/covenant-emulator/clientcontroller"
 	"github.com/stretchr/testify/require"
 )
 
@@ -47,4 +48,21 @@ func TestCovenantEmulatorLifeCycle(t *testing.T) {
 	res, err := tm.CovenantEmulator.AddCovenantSignatures(dels)
 	require.NoError(t, err)
 	require.Empty(t, res)
+}
+
+func TestQueryPendingDelegations(t *testing.T) {
+	tm, btcPks := StartManagerWithFinalityProvider(t, 1)
+	defer tm.Stop(t)
+
+	// manually sets the pg to a low value
+	clientcontroller.MaxPaginationLimit = 2
+
+	numDels := 3
+	for i := 0; i < numDels; i++ {
+		_ = tm.InsertBTCDelegation(t, btcPks, stakingTime, stakingAmount, false)
+	}
+
+	dels, err := tm.CovBBNClient.QueryPendingDelegations(uint64(numDels))
+	require.NoError(t, err)
+	require.Len(t, dels, numDels)
 }

--- a/itest/test_manager.go
+++ b/itest/test_manager.go
@@ -273,6 +273,7 @@ func (tm *TestManager) WaitForNPendingDels(t *testing.T, n int) []*types.Delegat
 	require.Eventually(t, func() bool {
 		dels, err = tm.CovBBNClient.QueryPendingDelegations(
 			tm.CovenanConfig.DelegationLimit,
+			nil,
 		)
 		if err != nil {
 			return false

--- a/itest/test_manager.go
+++ b/itest/test_manager.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"os/exec"
 	"sync"
 	"testing"
 	"time"
@@ -169,6 +170,7 @@ func StartManager(t *testing.T) *TestManager {
 	}
 
 	tm.WaitForServicesStart(t)
+	tm.SendToAddr(t, keyInfo.Address.String(), "100000ubbn")
 
 	return tm
 }
@@ -185,6 +187,23 @@ func (tm *TestManager) WaitForServicesStart(t *testing.T) {
 	}, eventuallyWaitTimeOut, eventuallyPollTime)
 
 	t.Logf("Babylon node is started")
+}
+
+func (tm *TestManager) SendToAddr(t *testing.T, toAddr, amount string) {
+	sendTx := exec.Command(
+		"babylond",
+		"tx",
+		"bank",
+		"send",
+		"node0",
+		toAddr,
+		amount,
+		"--keyring-backend=test",
+		"--chain-id=chain-test",
+		fmt.Sprintf("--home=%s", tm.BabylonHandler.babylonNode.nodeHome),
+	)
+	err := sendTx.Start()
+	require.NoError(t, err)
 }
 
 func StartManagerWithFinalityProvider(t *testing.T, n int) (*TestManager, []*btcec.PublicKey) {

--- a/testutil/mocks/babylon.go
+++ b/testutil/mocks/babylon.go
@@ -7,6 +7,7 @@ package mocks
 import (
 	reflect "reflect"
 
+	clientcontroller "github.com/babylonlabs-io/covenant-emulator/clientcontroller"
 	types "github.com/babylonlabs-io/covenant-emulator/types"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -49,18 +50,18 @@ func (mr *MockClientControllerMockRecorder) Close() *gomock.Call {
 }
 
 // QueryPendingDelegations mocks base method.
-func (m *MockClientController) QueryPendingDelegations(limit uint64) ([]*types.Delegation, error) {
+func (m *MockClientController) QueryPendingDelegations(limit uint64, filter clientcontroller.FilterFn) ([]*types.Delegation, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "QueryPendingDelegations", limit)
+	ret := m.ctrl.Call(m, "QueryPendingDelegations", limit, filter)
 	ret0, _ := ret[0].([]*types.Delegation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // QueryPendingDelegations indicates an expected call of QueryPendingDelegations.
-func (mr *MockClientControllerMockRecorder) QueryPendingDelegations(limit interface{}) *gomock.Call {
+func (mr *MockClientControllerMockRecorder) QueryPendingDelegations(limit, filter interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryPendingDelegations", reflect.TypeOf((*MockClientController)(nil).QueryPendingDelegations), limit)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryPendingDelegations", reflect.TypeOf((*MockClientController)(nil).QueryPendingDelegations), limit, filter)
 }
 
 // QueryStakingParamsByVersion mocks base method.


### PR DESCRIPTION
The query should loop by the max limit set in the config `delegationlimit`, since the BTC delegations already signed and the ones in which the covenant pub key was not constructed with are being removed by [sanitizeDelegations](https://github.com/babylonlabs-io/covenant-emulator/blob/37d715ecc3ed1902798998edfd00fec21d674ade/covenant/covenant.go#L476)


Closes: #92 