### PR TITLE
additional covenant signer metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * [#95](https://github.com/babylonlabs-io/covenant-emulator/pull/95) removed local signer option
 as the covenant emulator should only connect to a remote signer
 * [#96](https://github.com/babylonlabs-io/covenant-emulator/pull/96) add pagination to `queryDelegationsWithStatus`
+* [#99](https://github.com/babylonlabs-io/covenant-emulator/pull/99) add more metrics
+covenant-signer
 
 ## v0.11.3
 

--- a/covenant-signer/observability/metrics/signer.go
+++ b/covenant-signer/observability/metrics/signer.go
@@ -6,10 +6,12 @@ import (
 )
 
 type CovenantSignerMetrics struct {
-	Registry                  *prometheus.Registry
-	ReceivedSigningRequests   prometheus.Counter
-	SuccessfulSigningRequests prometheus.Counter
-	FailedSigningRequests     prometheus.Counter
+	Registry                   *prometheus.Registry
+	ReceivedSigningRequests    prometheus.Counter
+	SuccessfulSigningRequests  prometheus.Counter
+	FailedSigningRequests      prometheus.Counter
+	SignerUnlockStatus         prometheus.Gauge
+	SignerFailedUnlockRequests prometheus.Counter
 }
 
 func NewCovenantSignerMetrics() *CovenantSignerMetrics {
@@ -30,6 +32,14 @@ func NewCovenantSignerMetrics() *CovenantSignerMetrics {
 			Name: "signer_failed_signing_requests",
 			Help: "The total number of times signer responded with an internal error",
 		}),
+		SignerUnlockStatus: registerer.NewGauge(prometheus.GaugeOpts{
+			Name: "signer_unlock_status",
+			Help: "The status indicating if the signer is unlocked or locked. 1 for unlocked, 0 for locked",
+		}),
+		SignerFailedUnlockRequests: registerer.NewCounter(prometheus.CounterOpts{
+			Name: "signer_failed_unlock_requests",
+			Help: "The total number of times the signer failed to unlock",
+		}),
 	}
 
 	return uwMetrics
@@ -45,4 +55,16 @@ func (m *CovenantSignerMetrics) IncSuccessfulSigningRequests() {
 
 func (m *CovenantSignerMetrics) IncFailedSigningRequests() {
 	m.FailedSigningRequests.Inc()
+}
+
+func (m *CovenantSignerMetrics) SetSignerUnlocked() {
+	m.SignerUnlockStatus.Set(1)
+}
+
+func (m *CovenantSignerMetrics) SetSignerLocked() {
+	m.SignerUnlockStatus.Set(0)
+}
+
+func (m *CovenantSignerMetrics) IncFailedUnlockRequests() {
+	m.SignerFailedUnlockRequests.Inc()
 }

--- a/covenant-signer/signerservice/handlers/signtransactions.go
+++ b/covenant-signer/signerservice/handlers/signtransactions.go
@@ -64,8 +64,11 @@ func (h *Handler) Unlock(request *http.Request) (*Result, *types.Error) {
 
 	err = h.s.Unlock(request.Context(), payload.Passphrase)
 	if err != nil {
+		h.m.IncFailedUnlockRequests()
 		return nil, types.NewErrorWithMsg(http.StatusBadRequest, types.BadRequest, err.Error())
 	}
+
+	h.m.SetSignerUnlocked()
 
 	return NewResult(&types.UnlockResponse{}), nil
 }
@@ -75,6 +78,8 @@ func (h *Handler) Lock(request *http.Request) (*Result, *types.Error) {
 	if err != nil {
 		return nil, types.NewErrorWithMsg(http.StatusBadRequest, types.BadRequest, err.Error())
 	}
+
+	h.m.SetSignerLocked()
 
 	return NewResult(&types.LockResponse{}), nil
 }


### PR DESCRIPTION
fixes: https://github.com/babylonlabs-io/covenant-emulator/issues/79

Add also metric for failed unlock requests, as this may indicate that unauthorized entity have and access to signer api.