### PR TITLE
fix: Max request body size check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Improvements
 
+* [#109](https://github.com/babylonlabs-io/covenant-emulator/pull/109) HMAC authentication between signer and emulator.
 * [#110](https://github.com/babylonlabs-io/covenant-emulator/pull/110) bump babylon to v1.0.0-rc.7
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Improvements
 
+* [#111](https://github.com/babylonlabs-io/covenant-emulator/pull/111) Max request body size check.
 * [#109](https://github.com/babylonlabs-io/covenant-emulator/pull/109) HMAC authentication between signer and emulator.
 * [#110](https://github.com/babylonlabs-io/covenant-emulator/pull/110) bump babylon to v1.0.0-rc.7
 

--- a/covenant-signer/signerservice/middlewares/hmac_auth_test.go
+++ b/covenant-signer/signerservice/middlewares/hmac_auth_test.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"github.com/babylonlabs-io/covenant-emulator/covenant-signer/signerservice/middlewares"
-	"github.com/babylonlabs-io/covenant-emulator/covenant-signer/signerservice/types"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/babylonlabs-io/covenant-emulator/covenant-signer/signerservice/middlewares"
+	"github.com/babylonlabs-io/covenant-emulator/covenant-signer/signerservice/types"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
Add max request body size to avoid reading data without considering how big it can be.