### PR TITLE
fix: Add health check endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Improvements
 
+* [#109](https://github.com/babylonlabs-io/covenant-emulator/pull/109) HMAC authentication between signer and emulator.
 * [#110](https://github.com/babylonlabs-io/covenant-emulator/pull/110) bump babylon to v1.0.0-rc.7
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Improvements
 
+* [#116](https://github.com/babylonlabs-io/covenant-emulator/pull/116) Add health check to prometheus server.
 * [#114](https://github.com/babylonlabs-io/covenant-emulator/pull/114) bump babylon to v1.0.0-rc.8
 * [#109](https://github.com/babylonlabs-io/covenant-emulator/pull/109) HMAC authentication between signer and emulator.
 

--- a/covenant/covenant.go
+++ b/covenant/covenant.go
@@ -625,7 +625,7 @@ func (ce *CovenantEmulator) CheckReadiness() error {
 	// Check connectivity to the remote signer by calling its PubKey endpoint
 	_, err := ce.signer.PubKey()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get public key from covenant signer: %w", err)
 	}
 
 	return nil

--- a/covenant/covenant.go
+++ b/covenant/covenant.go
@@ -610,3 +610,23 @@ func (ce *CovenantEmulator) Stop() error {
 	})
 	return stopErr
 }
+
+// CheckReadiness checks if the covenant emulator is ready to serve requests.
+// It verifies internal state (if the main loop is running) and connectivity to
+// dependencies (remote signer).
+func (ce *CovenantEmulator) CheckReadiness() error {
+	select {
+	case <-ce.quit:
+		return fmt.Errorf("emulator is not running")
+	default:
+		// Emulator is running
+	}
+
+	// Check connectivity to the remote signer by calling its PubKey endpoint
+	_, err := ce.signer.PubKey()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/covenant/service/server.go
+++ b/covenant/service/server.go
@@ -44,6 +44,8 @@ func (s *CovenantServer) RunUntilShutdown() error {
 	}
 
 	ps := NewPrometheusServer(promAddr, metricsCfg.UpdateInterval, s.logger)
+	// Set the covenant emulator as the readiness checker
+	ps.SetReadinessChecker(s.ce)
 
 	defer func() {
 		ps.Stop()

--- a/docs/covenant-emulator-setup.md
+++ b/docs/covenant-emulator-setup.md
@@ -12,6 +12,8 @@ daemon program.
 	2. [Configure the covenant emulator](#32-configure-the-covenant-emulator)
 4. [Generate key pairs](#4-generate-key-pairs)
 5. [Start the emulator daemon](#5-start-the-emulator-daemon)
+6. [Monitoring and Health Checks](#6-monitoring-and-health-checks)
+	1. [Readiness Check Endpoint](#61-readiness-check-endpoint)
 
 ## 1. Prerequisites
 
@@ -221,3 +223,34 @@ covd start
 
 All the available CLI options can be viewed using the `--help` flag. These
 options can also be set in the configuration file.
+
+## 6. Monitoring and Health Checks
+
+### 6.1. Readiness Check Endpoint
+
+The covenant emulator provides a health check endpoint at `/health` that can be used 
+by monitoring systems, to determine if the service is ready to handle requests.
+
+The endpoint can be accessed through the same address as the Prometheus metrics endpoint, 
+which is configured in `covd.conf`:
+
+```
+http://<prometheusAddr>/health
+```
+
+The endpoint returns:
+- `HTTP 200 OK` with response body "Healthy" when the emulator is running properly
+and can connect to its dependencies
+- `HTTP 503 Service Unavailable` with an error message when the emulator is not ready
+
+The readiness check verifies:
+1. Whether the emulator's main loop is running
+2. Connectivity to the remote signer by calling its PubKey endpoint
+
+#### Example Usage
+
+To check the emulator's readiness:
+
+```bash
+curl -v http://127.0.0.1:2112/health
+```


### PR DESCRIPTION
Adds a health check endpoint to the prometheus server which checks if the loop is running and if the signer PubKey function is reachable.