### PR TITLE
fix: make passphrase optional for Unlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Improvements
 
+* [#119](https://github.com/babylonlabs-io/covenant-emulator/pull/119) Make passphrase for Unlock optional.
 * [#116](https://github.com/babylonlabs-io/covenant-emulator/pull/116) Add health check to prometheus server.
 * [#117](https://github.com/babylonlabs-io/covenant-emulator/pull/117) Add health check on startup, increase gas adjustment and update docs.
 

--- a/covenant-signer/signerservice/types/unlock.go
+++ b/covenant-signer/signerservice/types/unlock.go
@@ -1,7 +1,7 @@
 package types
 
 type UnlockRequest struct {
-	Passphrase string `json:"passphrase"`
+	Passphrase string `json:"passphrase,omitempty"`
 }
 
 type UnlockResponse struct{}

--- a/covenant-signer/signerservice/types/unlock.go
+++ b/covenant-signer/signerservice/types/unlock.go
@@ -1,5 +1,8 @@
 package types
 
+// UnlockRequest represents a request to unlock the key.
+// Note: When using the file keyring backend, the passphrase will be prompted
+// interactively in the terminal, so it doesn't need to be included in this request.
 type UnlockRequest struct {
 	Passphrase string `json:"passphrase,omitempty"`
 }


### PR DESCRIPTION
Passphrase for the Unlock request might not be needed as the operators using `file` keyring backend will be prompted to input a password through the interactive prompt anyway. Instead of removing it from usage completely just omitting it on empty seems the least invasive. 