### PR TITLE
chore: Bump CI workflows and pin to SHA hashes

### DIFF
--- a/.github/workflows/changelog-reminder.yml
+++ b/.github/workflows/changelog-reminder.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   changelog_reminder:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_changelog_reminder.yml@v0.7.0
+    uses: babylonlabs-io/.github/.github/workflows/reusable_changelog_reminder.yml@5151754256060bf160c411d0784f831f29882106 # v0.13.4
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,11 @@ permissions:
       
 jobs:
   lint_test:
+<<<<<<< Updated upstream
     uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@v0.13.4
+=======
+    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@5151754256060bf160c411d0784f831f29882106 # v0.13.4
+>>>>>>> Stashed changes
     with:
       go-version: '1.25'
       go-lint-version: 'v2.4.0'
@@ -22,7 +26,11 @@ jobs:
       gosec-args: "-exclude-generated -exclude-dir=itest -exclude-dir=testutil -exclude-dir=covenant-signer ./..."
 
   docker_pipeline:
+<<<<<<< Updated upstream
     uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.13.4
+=======
+    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@5151754256060bf160c411d0784f831f29882106 # v0.13.4
+>>>>>>> Stashed changes
     secrets: inherit
     with:
       publish: false
@@ -50,7 +58,11 @@ jobs:
         run: gosec ./...
 
   docker_pipeline_covenant_signer:
+<<<<<<< Updated upstream
     uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.13.4
+=======
+    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@5151754256060bf160c411d0784f831f29882106 # v0.13.4
+>>>>>>> Stashed changes
     secrets: inherit
     with:
       publish: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,7 @@ permissions:
       
 jobs:
   lint_test:
-<<<<<<< Updated upstream
-    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@v0.13.4
-=======
     uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@5151754256060bf160c411d0784f831f29882106 # v0.13.4
->>>>>>> Stashed changes
     with:
       go-version: '1.25'
       go-lint-version: 'v2.4.0'
@@ -26,11 +22,7 @@ jobs:
       gosec-args: "-exclude-generated -exclude-dir=itest -exclude-dir=testutil -exclude-dir=covenant-signer ./..."
 
   docker_pipeline:
-<<<<<<< Updated upstream
-    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.13.4
-=======
     uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@5151754256060bf160c411d0784f831f29882106 # v0.13.4
->>>>>>> Stashed changes
     secrets: inherit
     with:
       publish: false
@@ -58,11 +50,7 @@ jobs:
         run: gosec ./...
 
   docker_pipeline_covenant_signer:
-<<<<<<< Updated upstream
-    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.13.4
-=======
     uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@5151754256060bf160c411d0784f831f29882106 # v0.13.4
->>>>>>> Stashed changes
     secrets: inherit
     with:
       publish: false

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -9,5 +9,5 @@ permissions:
 
 jobs:
   release:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_go_releaser.yml@v0.7.0
+    uses: babylonlabs-io/.github/.github/workflows/reusable_go_releaser.yml@5151754256060bf160c411d0784f831f29882106 # v0.13.4
     secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,12 +20,8 @@ permissions:
 
 jobs:
   lint_test:
-<<<<<<< Updated upstream
-    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@v0.13.4
-    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs['skip-lint-test'] == true) }}
-=======
     uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@5151754256060bf160c411d0784f831f29882106 # v0.13.4
->>>>>>> Stashed changes
+    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs['skip-lint-test'] == true) }}
     with:
       go-version: '1.25'
       go-lint-version: 'v2.4.0'
@@ -44,11 +40,7 @@ jobs:
             needs.lint_test.result == 'success'
           )}}
     needs: ["lint_test"]
-<<<<<<< Updated upstream
-    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.13.4
-=======
     uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@5151754256060bf160c411d0784f831f29882106 # v0.13.4
->>>>>>> Stashed changes
     secrets: inherit
     with:
       publish: true
@@ -82,11 +74,7 @@ jobs:
   
   docker_pipeline_covenant_signer:
     needs: ["go_sec_covenant_signer"]
-<<<<<<< Updated upstream
-    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.13.4
-=======
     uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@5151754256060bf160c411d0784f831f29882106 # v0.13.4
->>>>>>> Stashed changes
     secrets: inherit
     with:
       publish: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,8 +20,12 @@ permissions:
 
 jobs:
   lint_test:
+<<<<<<< Updated upstream
     uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@v0.13.4
     if: ${{ !(github.event_name == 'workflow_dispatch' && inputs['skip-lint-test'] == true) }}
+=======
+    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@5151754256060bf160c411d0784f831f29882106 # v0.13.4
+>>>>>>> Stashed changes
     with:
       go-version: '1.25'
       go-lint-version: 'v2.4.0'
@@ -40,7 +44,11 @@ jobs:
             needs.lint_test.result == 'success'
           )}}
     needs: ["lint_test"]
+<<<<<<< Updated upstream
     uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.13.4
+=======
+    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@5151754256060bf160c411d0784f831f29882106 # v0.13.4
+>>>>>>> Stashed changes
     secrets: inherit
     with:
       publish: true
@@ -74,7 +82,11 @@ jobs:
   
   docker_pipeline_covenant_signer:
     needs: ["go_sec_covenant_signer"]
+<<<<<<< Updated upstream
     uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.13.4
+=======
+    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@5151754256060bf160c411d0784f831f29882106 # v0.13.4
+>>>>>>> Stashed changes
     secrets: inherit
     with:
       publish: true


### PR DESCRIPTION
This PR bumps all the reusable git workflows to the latest available version, and pins them all to commit hashes instead of git tags for additional security.