### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/changelog-reminder.yml
+++ b/.github/workflows/changelog-reminder.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   changelog_reminder:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_changelog_reminder.yml@0adff9d36a387ebfc921621f2e6b357230f8c08e # v0.18.0 and up
+    uses: babylonlabs-io/.github/.github/workflows/reusable_changelog_reminder.yml@98e4de18638b3d0738c9cbf7e7dfc6e34524db54 # v0.19.1 https://github.com/babylonlabs-io/.github/releases/tag/v0.19.1
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   lint_test:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@0adff9d36a387ebfc921621f2e6b357230f8c08e # v0.18.0 and up
+    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@98e4de18638b3d0738c9cbf7e7dfc6e34524db54 # v0.19.1 https://github.com/babylonlabs-io/.github/releases/tag/v0.19.1
     with:
       go-version: '1.25'
       go-lint-version: 'v2.4.0'
@@ -27,7 +27,7 @@ jobs:
       id-token: write        # Required for AWS OIDC
       security-events: write # Required for Trivy SARIF uploads
       packages: read         # Required to fetch internal or private CodeQL packs
-    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@0adff9d36a387ebfc921621f2e6b357230f8c08e # v0.18.0 and up
+    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@98e4de18638b3d0738c9cbf7e7dfc6e34524db54 # v0.19.1 https://github.com/babylonlabs-io/.github/releases/tag/v0.19.1
     secrets: inherit
     with:
       publish: false
@@ -41,9 +41,9 @@ jobs:
       GO111MODULE: on
     steps:
       - name: Fetch Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5 https://github.com/actions/setup-go/releases/tag/v5
         with:
           go-version: '^1.25.x'
           check-latest: true
@@ -60,7 +60,7 @@ jobs:
       id-token: write        # Required for AWS OIDC
       security-events: write # Required for Trivy SARIF uploads
       packages: read         # Required to fetch internal or private CodeQL packs
-    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@0adff9d36a387ebfc921621f2e6b357230f8c08e # v0.18.0 and up
+    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@98e4de18638b3d0738c9cbf7e7dfc6e34524db54 # v0.19.1 https://github.com/babylonlabs-io/.github/releases/tag/v0.19.1
     secrets: inherit
     with:
       publish: false

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -9,5 +9,5 @@ permissions:
 
 jobs:
   release:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_go_releaser.yml@0adff9d36a387ebfc921621f2e6b357230f8c08e # v0.18.0 and up
+    uses: babylonlabs-io/.github/.github/workflows/reusable_go_releaser.yml@98e4de18638b3d0738c9cbf7e7dfc6e34524db54 # v0.19.1 https://github.com/babylonlabs-io/.github/releases/tag/v0.19.1
     secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   lint_test:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@0adff9d36a387ebfc921621f2e6b357230f8c08e # v0.18.0 and up
+    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@98e4de18638b3d0738c9cbf7e7dfc6e34524db54 # v0.19.1 https://github.com/babylonlabs-io/.github/releases/tag/v0.19.1
     if: ${{ !(github.event_name == 'workflow_dispatch' && inputs['skip-lint-test'] == true) }}
     with:
       go-version: '1.25'
@@ -40,7 +40,7 @@ jobs:
             needs.lint_test.result == 'success'
           )}}
     needs: ["lint_test"]
-    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@0adff9d36a387ebfc921621f2e6b357230f8c08e # v0.18.0 and up
+    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@98e4de18638b3d0738c9cbf7e7dfc6e34524db54 # v0.19.1 https://github.com/babylonlabs-io/.github/releases/tag/v0.19.1
     secrets: inherit
     with:
       publish: true
@@ -62,9 +62,9 @@ jobs:
       GO111MODULE: on
     steps:
       - name: Fetch Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5 https://github.com/actions/setup-go/releases/tag/v5
         with:
           go-version: '^1.25.x'
           check-latest: true
@@ -77,7 +77,7 @@ jobs:
 
   docker_pipeline_covenant_signer:
     needs: ["go_sec_covenant_signer"]
-    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@0adff9d36a387ebfc921621f2e6b357230f8c08e # v0.18.0 and up
+    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@98e4de18638b3d0738c9cbf7e7dfc6e34524db54 # v0.19.1 https://github.com/babylonlabs-io/.github/releases/tag/v0.19.1
     secrets: inherit
     with:
       publish: true


### PR DESCRIPTION
## Summary

- Pin all `uses:` references in `.github/workflows/` to full 40-char commit SHAs
- Version tag preserved in trailing comment (e.g. `# v6.0.2 https://...`) for readability

## Why

SHA pinning prevents supply-chain attacks: a version tag can be silently force-pushed to malicious code, but a commit SHA is immutable.

## Files changed

-     Files updated: changelog-reminder.yml ci.yml goreleaser.yml publish.yml
-       - babylonlabs-io/.github/.github/workflows/reusable_changelog_reminder.yml@98e4de18638b3d0738c9cbf7e7dfc6e34524db54 # v0.19.1
-       - babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@98e4de18638b3d0738c9cbf7e7dfc6e34524db54 # v0.19.1
-       - babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@98e4de18638b3d0738c9cbf7e7dfc6e34524db54 # v0.19.1
-       - babylonlabs-io/.github/.github/workflows/reusable_go_releaser.yml@98e4de18638b3d0738c9cbf7e7dfc6e34524db54 # v0.19.1
-  .github/workflows/changelog-reminder.yml |  2 +-
-  .github/workflows/ci.yml                 | 10 +++++-----
-  .github/workflows/goreleaser.yml         |  2 +-
-  .github/workflows/publish.yml            | 10 +++++-----

## Pinned actions

- actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
- actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
- babylonlabs-io/.github/.github/workflows/reusable_changelog_reminder.yml@98e4de18638b3d0738c9cbf7e7dfc6e34524db54 # v0.19.1
- babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@98e4de18638b3d0738c9cbf7e7dfc6e34524db54 # v0.19.1
- babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@98e4de18638b3d0738c9cbf7e7dfc6e34524db54 # v0.19.1
- babylonlabs-io/.github/.github/workflows/reusable_go_releaser.yml@98e4de18638b3d0738c9cbf7e7dfc6e34524db54 # v0.19.1