### PR TITLE
fix: race condition in covenant-signer KeyringRetriever PrivKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
 
+### Bug Fixes
+
+* [#200](https://github.com/babylonlabs-io/covenant-emulator/pull/200) fix: race condition in covenant-signer `KeyringRetriever.PrivKey` where a concurrent `Lock()` could zero an in-use private key
+
 ### Improvements
 
 * [#196](https://github.com/babylonlabs-io/covenant-emulator/pull/196) chore(deps): bump go-getter to v1.8.6 (aws-sdk-go v1 to v2 migration)

--- a/covenant-signer/keystore/cosmos/cosmoskeyretriever.go
+++ b/covenant-signer/keystore/cosmos/cosmoskeyretriever.go
@@ -45,7 +45,13 @@ func (k *KeyringRetriever) PrivKey(_ context.Context) (*btcec.PrivateKey, error)
 		return nil, fmt.Errorf("private key is not unlocked. Please call Unlock() first")
 	}
 
-	return k.btcecPrivKey, nil
+	// Return an isolated copy so the caller does not hold a reference to the
+	// stored key. Otherwise a concurrent Lock() would zero the underlying
+	// memory while the caller is still signing with it.
+	keyBytes := k.btcecPrivKey.Serialize()
+	privKeyCopy, _ := btcec.PrivKeyFromBytes(keyBytes)
+
+	return privKeyCopy, nil
 }
 
 func (k *KeyringRetriever) Unlock(_ context.Context, passphrase string) error {

--- a/covenant-signer/keystore/cosmos/cosmoskeyretriever_test.go
+++ b/covenant-signer/keystore/cosmos/cosmoskeyretriever_test.go
@@ -1,0 +1,70 @@
+package cosmos_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/babylonlabs-io/covenant-emulator/covenant-signer/config"
+	"github.com/babylonlabs-io/covenant-emulator/covenant-signer/keystore/cosmos"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPrivKeyConcurrentLockNoRace ensures that a key returned by PrivKey() is an
+// isolated copy: a concurrent Lock() that zeroes the stored key must not corrupt
+// the key a signer is still using. Run with -race to catch regressions.
+func TestPrivKeyConcurrentLockNoRace(t *testing.T) {
+	ctx := context.Background()
+
+	const (
+		chainID    = "test-chain"
+		keyName    = "test-covenant-key"
+		backend    = "test"
+		passphrase = ""
+		hdPath     = "m/44'/0'/0'/0/0"
+	)
+
+	keyDir := t.TempDir()
+	_, err := cosmos.CreateCovenantKey(keyDir, chainID, keyName, backend, passphrase, hdPath)
+	require.NoError(t, err)
+
+	retriever, err := cosmos.NewCosmosKeyringRetriever(&config.CosmosKeyStoreConfig{
+		ChainID:        chainID,
+		KeyDirectory:   keyDir,
+		KeyringBackend: backend,
+		KeyName:        keyName,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, retriever.Unlock(ctx, passphrase))
+
+	privKey, err := retriever.PrivKey(ctx)
+	require.NoError(t, err)
+	pubKeyBefore := privKey.PubKey().SerializeCompressed()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		pk, pkErr := retriever.PrivKey(ctx)
+		require.NoError(t, pkErr)
+		// Hold the copy across a window where Lock() runs, then read from it.
+		time.Sleep(10 * time.Millisecond)
+		require.Equal(t, pubKeyBefore, pk.PubKey().SerializeCompressed(),
+			"copy returned by PrivKey() must not be affected by a concurrent Lock()")
+	}()
+
+	go func() {
+		defer wg.Done()
+		time.Sleep(1 * time.Millisecond)
+		require.NoError(t, retriever.Lock(ctx))
+	}()
+
+	wg.Wait()
+
+	// After Lock(), the retriever has no key and must report it.
+	_, err = retriever.PrivKey(ctx)
+	require.ErrorContains(t, err, "not unlocked")
+}

--- a/covenant-signer/keystore/cosmos/cosmoskeyretriever_test.go
+++ b/covenant-signer/keystore/cosmos/cosmoskeyretriever_test.go
@@ -43,26 +43,40 @@ func TestPrivKeyConcurrentLockNoRace(t *testing.T) {
 	require.NoError(t, err)
 	pubKeyBefore := privKey.PubKey().SerializeCompressed()
 
-	var wg sync.WaitGroup
+	// Collect results in the workers and assert on the test goroutine:
+	// require.* calls t.FailNow(), which is only safe on the test goroutine.
+	var (
+		wg         sync.WaitGroup
+		signErr    error
+		signPubKey []byte
+		lockErr    error
+	)
 	wg.Add(2)
 
 	go func() {
 		defer wg.Done()
-		pk, pkErr := retriever.PrivKey(ctx)
-		require.NoError(t, pkErr)
+		pk, err := retriever.PrivKey(ctx)
+		if err != nil {
+			signErr = err
+			return
+		}
 		// Hold the copy across a window where Lock() runs, then read from it.
 		time.Sleep(10 * time.Millisecond)
-		require.Equal(t, pubKeyBefore, pk.PubKey().SerializeCompressed(),
-			"copy returned by PrivKey() must not be affected by a concurrent Lock()")
+		signPubKey = pk.PubKey().SerializeCompressed()
 	}()
 
 	go func() {
 		defer wg.Done()
 		time.Sleep(1 * time.Millisecond)
-		require.NoError(t, retriever.Lock(ctx))
+		lockErr = retriever.Lock(ctx)
 	}()
 
 	wg.Wait()
+
+	require.NoError(t, signErr)
+	require.NoError(t, lockErr)
+	require.Equal(t, pubKeyBefore, signPubKey,
+		"copy returned by PrivKey() must not be affected by a concurrent Lock()")
 
 	// After Lock(), the retriever has no key and must report it.
 	_, err = retriever.PrivKey(ctx)

--- a/covenant-signer/keystore/cosmos/cosmoskeyretriever_test.go
+++ b/covenant-signer/keystore/cosmos/cosmoskeyretriever_test.go
@@ -53,21 +53,26 @@ func TestPrivKeyConcurrentLockNoRace(t *testing.T) {
 	)
 	wg.Add(2)
 
+	// gotKey guarantees the signer goroutine has obtained its key before Lock()
+	// runs, so the test exercises the "Lock while a key is held" path
+	// deterministically instead of relying on goroutine scheduling.
+	gotKey := make(chan struct{})
+
 	go func() {
 		defer wg.Done()
 		pk, err := retriever.PrivKey(ctx)
-		if err != nil {
-			signErr = err
-			return
+		close(gotKey)
+		signErr = err
+		if err == nil {
+			// Hold the copy across a window where Lock() runs, then read from it.
+			time.Sleep(10 * time.Millisecond)
+			signPubKey = pk.PubKey().SerializeCompressed()
 		}
-		// Hold the copy across a window where Lock() runs, then read from it.
-		time.Sleep(10 * time.Millisecond)
-		signPubKey = pk.PubKey().SerializeCompressed()
 	}()
 
 	go func() {
 		defer wg.Done()
-		time.Sleep(1 * time.Millisecond)
+		<-gotKey
 		lockErr = retriever.Lock(ctx)
 	}()
 


### PR DESCRIPTION
## Summary

`KeyringRetriever.PrivKey()` returned the live `*btcec.PrivateKey` pointer after releasing its mutex. A concurrent `Lock()` calls `Zero()` on that exact memory, so under simultaneous sign + lock the in-use key was zeroed mid-signing — a genuine data race that yields invalid signatures (and a `WARNING: DATA RACE` at `cosmoskeyretriever.go` under `go test -race`).

The fix returns an isolated copy of the key under the mutex (`Serialize()` + `PrivKeyFromBytes()`), matching the pattern already used by `HardcodedPrivKeyRetriever`. The caller no longer shares memory with the stored key, so a subsequent `Lock()` cannot corrupt an in-flight signing operation.

## Impact

Availability-focused. Before the fix, a concurrent `Lock()` during signing produced invalid signatures (rejected downstream) rather than a clean error. No private-key disclosure and no forgery — corrupted signatures are computed against a zeroed/torn scalar and rejected by validation. Preconditions to hit it externally (signer on a non-loopback interface, HMAC disabled, key unlocked) are narrow, but the race is real and worth eliminating.

## Changes

- `covenant-signer/keystore/cosmos/cosmoskeyretriever.go` — `PrivKey()` returns an isolated copy under the mutex.
- `covenant-signer/keystore/cosmos/cosmoskeyretriever_test.go` — new regression test `TestPrivKeyConcurrentLockNoRace`.

## Testing

- `go test -race -run TestPrivKeyConcurrentLockNoRace ./covenant-signer/keystore/cosmos/...` passes with the fix.
- Temporarily reverting the fix makes the same test trip `WARNING: DATA RACE` at the `Zero()` call and fail — confirming it's a real regression guard.
- `go build ./covenant-signer/...` and `go vet` on the package are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)